### PR TITLE
Fix issue #1 (missing 'path' module)

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,3 +1,4 @@
+const path = require('path')
 const DirectoryNamedWebpackPlugin = require('directory-named-webpack-plugin')
 
 exports.onCreateWebpackConfig = ({ stage, actions }, { include, ...opts }) => {


### PR DESCRIPTION
Require the nodejs `path` module to fix the `path is not defined` error thrown in `onCreateWebpackConfig` in `gatsby-node.js`.

Details about the problem are mentioned in issue #1.